### PR TITLE
Fixed underlying socket issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 MODE Device library in NodeJS provides a wrapper for the [MODE](http://www.tinkermode.com) cloud [API](http://dev.tinkermode.com/docs/api/) and handles the data objects connecting Device.
 
 ## Requirements
-You need to install [Node.js](https://nodejs.org/) to use the library.
+You need to install [Node.js](https://nodejs.org/) to use the library.  This library works with v0.10.38, v0.12 and newer version of NodeJS.
 
 ## Installation
 
@@ -52,12 +52,15 @@ Or you can use `package.json` and add `mode-device` in the dependency section.
   device.listenCommands();
 ~~~
 
-If you want to see more detail how to use it on Raspberry Pi, please read [tutorial](http://dev.tinkermode.com/docs/raspberry_pi.html).
+If you want to see more detail how to use it on micro controllers like Raspberry Pi or Intel Edison, please read our tutorials:
+
+- [Using Raspberry Pi with MODE](http://dev.tinkermode.com/docs/raspberry_pi.html)
+- [Using Intel Edison with MODE](http://dev.tinkermode.com/docs/edison.html)
 
 
 ## Author
 
-Naoki Takano, honten@tinkermode.com
+MODE, inc.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ You need to install [Node.js](https://nodejs.org/) to use the library.
 
 We put the library at [npm package site](https://www.npmjs.com/package/mode-device), so you can just run the following command to install the library.
 
+```
 $ npm install mode-device
+```
 
 Or you can use `package.json` and add `mode-device` in the dependency section.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mode-device",
   "description": "MODE Device library",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": "MODE, Inc.",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mode-device",
   "description": "MODE Device library",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": "MODE, Inc.",
   "main": "index.js",
   "dependencies": {

--- a/sample/sample.js
+++ b/sample/sample.js
@@ -26,6 +26,6 @@ device.commandCallback = function(msg, flags) {
     var v = msg['parameters']['param0'] ? 1 : 0;
     // Do something
   }
-}
+};
 
 device.listenCommands();


### PR DESCRIPTION
On older node.js (v0.10.38), rapid event triggering ended up unreliable.  It was caused by a bug that we didn't read HTTP response bodies and underlying sockets were not released.
