### PR TITLE
Refactored to allow more flexibility for API host/port overrides.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "mode-device",
   "description": "MODE Device library",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "author": "MODE, Inc.",
   "main": "index.js",
   "dependencies": {
-    "ws": ">=0.7.1",
-    "https": "latest"
+    "ws": ">=0.7.1"
   },
   "repository" : {
     "type" : "git",


### PR DESCRIPTION
Made this change because I want to make it easier to test with my local dev environment, which don't have HTTPS.

Also switched to use a private http agent instead of the global one.

@honteng please review.
