### PR TITLE
Added handshake timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,8 @@ ModeDevice.prototype._wsConnect = function() {
     agent: this.apiHttpAgent,
     headers: {
       "Authorization": 'ModeCloud ' + this.token
-    }
+    },
+    handshakeTimeout: 20000
   });
 
   this._websocket.on('error', this._wsHandleError.bind(this));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "MODE, Inc.",
   "main": "index.js",
   "dependencies": {
-    "ws": "^2.0.0"
+    "ws": "^5.1.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
If handshake not completed but connection not closed, then none of the handlers get called and the device gets stuck, without any ping/pong timer. Encountered while trying modem on gateway.

This is a similar issue: https://bugs.chromium.org/p/chromium/issues/detail?id=391263